### PR TITLE
Fix several bugs that when getting columns info

### DIFF
--- a/driver/crdb.go
+++ b/driver/crdb.go
@@ -161,8 +161,8 @@ func (d *CockroachDBDriver) Columns(schema, tableName string, whitelist, blackli
 	query := `
 		select
 		distinct c.column_name,
-		max(c.data_type),
-		max(c.column_default),
+		max(c.data_type) as data_type,
+		max(c.column_default) as column_default,
 		bool_or(case when c.is_nullable = 'NO' then FALSE else TRUE end) as is_nullable,
 		bool_or(case when pc.count < 2 AND pgc.contype IN ('p', 'u') then TRUE else FALSE end) as is_unique
 		from information_schema.columns as c


### PR DESCRIPTION
After my previous PR, I noticed some extra edge cases that were not working as expected.
This PR should fix them.

1. When a column has multiple constraints, it is listed multiple times (fixed)
2. With a composite unique or PK index, it will mark both columns as unique (fixed)

**EXAMPLE SCHEMA**

```sql
CREATE TABLE users (
	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
	email STRING NULL,
	FAMILY "primary" (id, email)
);

CREATE TABLE posts (
	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
	user_id UUID NULL REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
	content STRING NULL,
	FAMILY "primary" (id, user_id, content)
);

CREATE TABLE comments (
	user_id UUID NULL REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
	post_id UUID NULL REFERENCES posts (id) ON DELETE CASCADE ON UPDATE CASCADE,
	content STRING NULL,
	PRIMARY KEY (user_id, post_id),
	FAMILY "primary" (user_id, post_id, content)
);
```

Running the previous query for the comments table:

```sql
select
distinct c.column_name,
c.data_type,
c.column_default,
(case when c.is_nullable = 'NO' then FALSE else TRUE end) as is_nullable,
(case when pgc.contype IS NOT NULL AND pgc.contype IN ('p', 'u') then TRUE else FALSE end) as is_unique
from information_schema.columns as c
left join information_schema.key_column_usage kcu on c.table_name = kcu.table_name
and c.table_schema = kcu.table_schema and c.column_name = kcu.column_name
left join pg_constraint pgc on kcu.constraint_name = pgc.conname
where c.table_schema = 'public' and c.table_name = 'comments';
```

Gives:

```
+-------------+-----------+----------------+-------------+-----------+
| column_name | data_type | column_default | is_nullable | is_unique |
+-------------+-----------+----------------+-------------+-----------+
| user_id     | UUID      | NULL           |    false    |   true    |
| user_id     | UUID      | NULL           |    false    |   false   |
| post_id     | UUID      | NULL           |    false    |   true    |
| post_id     | UUID      | NULL           |    false    |   false   |
| content     | STRING    | NULL           |    true     |   false   |
+-------------+-----------+----------------+-------------+-----------+
```

The modified query:

```sql
select
distinct c.column_name,
max(c.data_type) as data_type,
max(c.column_default) as column_default,
bool_or(case when c.is_nullable = 'NO' then FALSE else TRUE end) as is_nullable,
bool_or(case when pc.count < 2 AND pgc.contype IN ('p', 'u') then TRUE else FALSE end) as is_unique
from information_schema.columns as c
LEFT JOIN (
	select distinct c.column_name,
	pgc.conname as conname,
	pgc.contype as contype
	from information_schema.columns as c
	LEFT JOIN information_schema.key_column_usage kcu on c.table_name = kcu.table_name
	and c.table_schema = kcu.table_schema and c.column_name = kcu.column_name
	LEFT JOIN pg_constraint pgc on kcu.constraint_name = pgc.conname
) pgc on c.column_name = pgc.column_name
LEFT JOIN (
	select kcu.table_schema, kcu.table_name, kcu.constraint_name, count(*)
	from information_schema.key_column_usage kcu
	group by kcu.table_schema, kcu.table_name, kcu.constraint_name
) pc on c.table_schema = pc.table_schema and c.table_name = pc.table_name and pgc.conname = pc.constraint_name
where c.table_schema = 'public' and c.table_name = 'comments'
group by c.column_name;
```

Gives:

```
+-------------+-----------+----------------+-------------+-----------+
| column_name | data_type | column_default | is_nullable | is_unique |
+-------------+-----------+----------------+-------------+-----------+
| post_id     | UUID      | NULL           |    false    |   false   |
| content     | STRING    | NULL           |    true     |   false   |
| user_id     | UUID      | NULL           |    false    |   false   |
+-------------+-----------+----------------+-------------+-----------+
```