### PR TITLE
properly mark nullable fields as having default

### DIFF
--- a/driver/crdb.go
+++ b/driver/crdb.go
@@ -272,6 +272,13 @@ func (d *CockroachDBDriver) Columns(schema, tableName string, whitelist, blackli
 			return nil, errors.Wrapf(err, "unable to scan for table %s", tableName)
 		}
 
+		// To prevent marking nullable columns as not having a default value
+		// Techinically, every nullable column is "DEFAULT NULL"
+		if nullable && defaultValue == nil {
+			null := "NULL"
+			defaultValue = &null
+		}
+
 		// TODO(glerchundi): find a better way to infer this.
 		dbType := strings.ToLower(re.ReplaceAllString(colType, ""))
 		tmp := strings.Replace(dbType, "[]", "", 1)


### PR DESCRIPTION
Previously, nullable fields will be marked as not having a default.
Didn't really notice this problem until I switched to CockroachDB v20.1.1

However, all nullable fields technically have `DEFAULT NULL`, so I added a conditional to check for this.