### PR TITLE
Update constraint check regex

### DIFF
--- a/driver/override/templates_test/singleton/crdb_main_test.go.tpl
+++ b/driver/override/templates_test/singleton/crdb_main_test.go.tpl
@@ -1,4 +1,4 @@
-var rgxCDBFkey = regexp.MustCompile(`(?m)((\n)?.*CONSTRAINT.*?FOREIGN KEY.*?\n|(\n)?[a-zA-Z _]*VALIDATE CONSTRAINT.*?.*?\n)`)
+var rgxCDBFkey = regexp.MustCompile(`(?m)((\n)?.*CONSTRAINT.*?FOREIGN KEY.*?\n|(\n)?[a-zA-Z _\.]*VALIDATE CONSTRAINT.*?.*?\n)`)
 
 type crdbTester struct {
   dbConn *sql.DB


### PR DESCRIPTION
When using CRDB 1.21 the dump output includes the schema so we have to handle a `.` coming before the rest of the regex.

As can be seen from this output:

```
➜  serverservice git:(main) ✗ cockroach dump serverservice_test --insecure --dump-mode=schema | grep 'VALIDATE CONSTRAINT'
ALTER TABLE public.server_components VALIDATE CONSTRAINT fk_server_component_type_id_ref_server_component_types;
ALTER TABLE public.server_components VALIDATE CONSTRAINT fk_server_id_ref_servers;
```