### PR TITLE
Remove dependency on deprecated pkg/errors

### DIFF
--- a/driver/crdb.go
+++ b/driver/crdb.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/glerchundi/sqlboiler-crdb/v4/driver/override"
 	_ "github.com/lib/pq" // Side-effect import sql driver
-	"github.com/pkg/errors"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
 	"github.com/volatiletech/sqlboiler/v4/importers"
 	"github.com/volatiletech/strmangle"
@@ -76,7 +75,7 @@ func (d *CockroachDBDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBI
 	d.connStr = buildQueryString(user, pass, dbname, host, port, sslmode)
 	d.conn, err = sql.Open("postgres", d.connStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "sqlboiler-crdb failed to connect to database")
+		return nil, fmt.Errorf("sqlboiler-crdb failed to connect to database: %w", err)
 	}
 
 	defer func() {
@@ -273,7 +272,7 @@ func (d *CockroachDBDriver) Columns(schema, tableName string, whitelist, blackli
 		var defaultValue, arrayType *string
 		var nullable, unique bool
 		if err := rows.Scan(&colName, &ordinalPos, &colType, &defaultValue, &nullable, &unique); err != nil {
-			return nil, errors.Wrapf(err, "unable to scan for table %s", tableName)
+			return nil, fmt.Errorf("unable to scan for table %s: %w", tableName, err)
 		}
 
 		// To prevent marking nullable columns as not having a default value
@@ -577,7 +576,6 @@ func (d *CockroachDBDriver) Imports() (importers.Collection, error) {
 				`"strings"`,
 			},
 			ThirdParty: importers.List{
-				`"github.com/pkg/errors"`,
 				`"github.com/spf13/viper"`,
 				`"github.com/volatiletech/randomize"`,
 				`_ "github.com/lib/pq"`,

--- a/driver/override/templates_test/singleton/crdb_main_test.go.tpl
+++ b/driver/override/templates_test/singleton/crdb_main_test.go.tpl
@@ -53,23 +53,23 @@ func (c *crdbTester) setup() error {
   createCmd.Stdin = newFKeyDestroyer(rgxCDBFkey, r)
 
   if err = dumpCmd.Start(); err != nil {
-      return errors.Wrap(err, "failed to start 'cockroach dump' command")
+      return fmt.Errorf("failed to start 'cockroach dump' command: %w", err)
   }
   if err = createCmd.Start(); err != nil {
-      return errors.Wrap(err, "failed to start 'cockroach sql' command")
+      return fmt.Errorf("failed to start 'cockroach sql' command: %w", err)
   }
 
   if err = dumpCmd.Wait(); err != nil {
-      return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+      return fmt.Errorf("failed to wait for 'cockroach sql' command: %w", err)
   }
 
   // After dumpCmd is done, close the write end of the pipe
   if err = w.Close(); err != nil {
-      return errors.Wrap(err, "failed to close pipe")
+      return fmt.Errorf("failed to close pipe: %w", err)
   }
 
   if err = createCmd.Wait(); err != nil {
-      return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+      return fmt.Errorf("failed to wait for 'cockroach sql' command: %w", err)
   }
 
   return nil

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/lib/pq v1.5.1
-	github.com/pkg/errors v0.9.1
 	github.com/volatiletech/sqlboiler/v4 v4.10.2
 	github.com/volatiletech/strmangle v0.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Since volatiletech/sqlboiler only supports go 1.13 and above, we can safely discard the deprecated version pkg/errors in favor of the standard library version.