### PR TITLE
*: use stdlib errors package

### DIFF
--- a/driver/override/templates/17_upsert.go.tpl
+++ b/driver/override/templates/17_upsert.go.tpl
@@ -133,7 +133,7 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 		{{else -}}
 		err = exec.QueryRowContext(ctx, cache.query, vals...).Scan(returns...)
 		{{end -}}
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			err = nil // CockcorachDB doesn't return anything when there's no update
 		}
 	} else {
@@ -144,7 +144,7 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 		{{end -}}
 	}
 	if err != nil {
-		return errors.Wrap(err, "{{.PkgName}}: unable to upsert {{.Table.Name}}")
+		return fmt.Errorf("{{.PkgName}}: unable to upsert {{.Table.Name}}: %w", err)
 	}
 
 	if !cached {

--- a/driver/override/templates_test/singleton/crdb_main_test.go.tpl
+++ b/driver/override/templates_test/singleton/crdb_main_test.go.tpl
@@ -53,23 +53,23 @@ func (c *crdbTester) setup() error {
   createCmd.Stdin = newFKeyDestroyer(rgxCDBFkey, r)
 
   if err = dumpCmd.Start(); err != nil {
-      return errors.Wrap(err, "failed to start 'cockroach dump' command")
+      return fmt.Errorf("failed to start 'cockroach dump' command: %w", err)
   }
   if err = createCmd.Start(); err != nil {
-      return errors.Wrap(err, "failed to start 'cockroach sql' command")
+      return fmt.Errorf("failed to start 'cockroach sql' command: %w", err)
   }
 
   if err = dumpCmd.Wait(); err != nil {
-      return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+      return fmt.Errorf("failed to wait for 'cockroach sql' command: %w", err)
   }
 
   // After dumpCmd is done, close the write end of the pipe
   if err = w.Close(); err != nil {
-      return errors.Wrap(err, "failed to close pipe")
+      return fmt.Errorf("failed to close pipe: %w", err)
   }
 
   if err = createCmd.Wait(); err != nil {
-      return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+      return fmt.Errorf("failed to wait for 'cockroach sql' command: %w", err)
   }
 
   return nil

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/lib/pq v1.5.1
-	github.com/pkg/errors v0.9.1
 	github.com/volatiletech/sqlboiler/v4 v4.10.2
 	github.com/volatiletech/strmangle v0.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Check `sql.ErrNoRows` error using `errors.Is` instead of a equality check to support wrapping.

Remove the `github.com/pkg/errors` dependency and use the stdlib `errors` package instead.