### PR TITLE
fix(driver): skip composite foreign keys in ForeignKeyInfo

### DIFF
--- a/driver/crdb.go
+++ b/driver/crdb.go
@@ -405,6 +405,7 @@ WHERE
     pgn.nspname = $2
     AND pgc.relname = $1
     AND pgcon.contype = 'f'
+    AND array_length(pgcon.conkey, 1) = 1
 ORDER BY
     pgcon.conname DESC;`
 

--- a/driver/crdb.golden.json
+++ b/driver/crdb.golden.json
@@ -61,6 +61,78 @@
       "to_many_relationships": null
     },
     {
+      "name": "comment_replies",
+      "schema_name": "",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int64",
+          "db_type": "int8",
+          "default": "unique_rowid()",
+          "nullable": false,
+          "unique": true,
+          "validated": false,
+          "arr_type": null,
+          "udt_name": "",
+          "domain_name": null,
+          "full_db_type": "",
+          "auto_generated": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int64",
+          "db_type": "int8",
+          "default": "",
+          "nullable": false,
+          "unique": false,
+          "validated": false,
+          "arr_type": null,
+          "udt_name": "",
+          "domain_name": null,
+          "full_db_type": "",
+          "auto_generated": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "int64",
+          "db_type": "int8",
+          "default": "",
+          "nullable": false,
+          "unique": false,
+          "validated": false,
+          "arr_type": null,
+          "udt_name": "",
+          "domain_name": null,
+          "full_db_type": "",
+          "auto_generated": false
+        },
+        {
+          "name": "content",
+          "type": "null.String",
+          "db_type": "string",
+          "default": "",
+          "nullable": true,
+          "unique": false,
+          "validated": false,
+          "arr_type": null,
+          "udt_name": "",
+          "domain_name": null,
+          "full_db_type": "",
+          "auto_generated": false
+        }
+      ],
+      "p_key": {
+        "name": "primary",
+        "columns": [
+          "id"
+        ]
+      },
+      "f_keys": null,
+      "is_join_table": false,
+      "to_one_relationships": null,
+      "to_many_relationships": null
+    },
+    {
       "name": "posts",
       "schema_name": "",
       "columns": [

--- a/driver/testdatabase.sql
+++ b/driver/testdatabase.sql
@@ -3,6 +3,7 @@ drop table if exists video_tags;
 drop table if exists tags;
 drop table if exists videos;
 drop table if exists sponsors;
+drop table if exists comment_replies;
 drop table if exists comments;
 drop table if exists posts;
 drop table if exists users;
@@ -26,6 +27,18 @@ CREATE TABLE comments (
 	content string null,
 
 	primary key (user_id, post_id)
+);
+
+-- comment_replies has a composite FK to comments(user_id, post_id).
+-- The driver intentionally ignores composite FKs; only single-column FKs
+-- are reflected in the generated ORM code (see ForeignKeyInfo).
+create table comment_replies (
+	id serial primary key not null,
+	comment_user_id int not null,
+	comment_post_id int not null,
+	content string null,
+
+	foreign key (comment_user_id, comment_post_id) references comments (user_id, post_id)
 );
 
 create table sponsors (


### PR DESCRIPTION
SQLBoiler does not support composite foreign keys. When a table has a
multi-column FK constraint, the ForeignKeyInfo query was producing a
cartesian product of source and destination columns (one row per
combination), all sharing the same constraint name. This caused
SQLBoiler to generate duplicate relationship fields and methods, leading
to uncompilable Go output.

The upstream sqlboiler library (aarondl/sqlboiler PR #1299) addressed
this at the post-processing level in CombineConfigAndDBForeignKeys by
skipping any FK whose constraint name appears more than once. However,
the CRDB driver's query can produce cartesian-product rows whose
deduplication via DISTINCT is not deterministic across CockroachDB
versions, making the behaviour unreliable in practice.

Fix: add AND array_length(pgcon.conkey, 1) = 1 to the WHERE clause of
the ForeignKeyInfo SQL query. This restricts results to single-column FK
constraints only, ignoring composite FKs entirely at the driver level,
which is consistent with the intent of the upstream fix.

Composite FK constraints are still enforced by the database engine
(cascade deletes, referential integrity); they are simply not reflected
in the generated ORM relationship code, which is the correct behaviour
given that SQLBoiler has no support for them.

A comment_replies table is added to testdatabase.sql with a composite FK
referencing comments(user_id, post_id). The golden file is updated to
show f_keys: null for that table, locking in the intended behaviour.